### PR TITLE
FEATURE: Event stream filter

### DIFF
--- a/src/EventStoreInterface.php
+++ b/src/EventStoreInterface.php
@@ -4,6 +4,7 @@ namespace Neos\EventStore;
 
 use Neos\EventStore\Exception\ConcurrencyException;
 use Neos\EventStore\Model\EventStore\CommitResult;
+use Neos\EventStore\Model\EventStream\EventStreamFilter;
 use Neos\EventStore\Model\EventStream\EventStreamInterface;
 use Neos\EventStore\Model\EventStream\ExpectedVersion;
 use Neos\EventStore\Model\Event\StreamName;
@@ -12,7 +13,7 @@ use Neos\EventStore\Model\Events;
 
 interface EventStoreInterface
 {
-    public function load(StreamName|VirtualStreamName $streamName): EventStreamInterface;
+    public function load(StreamName|VirtualStreamName $streamName, EventStreamFilter $filter = null): EventStreamInterface;
 
     /**
      * @param StreamName $streamName

--- a/src/Model/Event/EventTypes.php
+++ b/src/Model/Event/EventTypes.php
@@ -1,0 +1,51 @@
+<?php
+declare(strict_types=1);
+namespace Neos\EventStore\Model\Event;
+
+use ArrayIterator;
+use IteratorAggregate;
+use Traversable;
+use Webmozart\Assert\Assert;
+
+/**
+ * @implements IteratorAggregate<EventType>
+ */
+final class EventTypes implements IteratorAggregate
+{
+    /**
+     * @param EventType[] $types
+     */
+    private function __construct(
+        public readonly array $types,
+    ) {
+        Assert::notEmpty($this->types, 'EventTypes must not be empty');
+    }
+
+    public static function create(EventType ...$types): self
+    {
+        return new self($types);
+    }
+
+    public function contains(EventType $type): bool
+    {
+        foreach ($this->types as $typesInSet) {
+            if ($typesInSet->value === $type->value) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * @return string[]
+     */
+    public function toStringArray(): array
+    {
+        return array_map(static fn (EventType $type) => $type->value, $this->types);
+    }
+
+    public function getIterator(): Traversable
+    {
+        return new ArrayIterator($this->types);
+    }
+}

--- a/src/Model/EventStream/EventStreamFilter.php
+++ b/src/Model/EventStream/EventStreamFilter.php
@@ -2,11 +2,16 @@
 declare(strict_types=1);
 namespace Neos\EventStore\Model\EventStream;
 
+use Neos\EventStore\EventStoreInterface;
 use Neos\EventStore\Model\Event\EventTypes;
-use Webmozart\Assert\Assert;
 
 /**
- * TODO
+ * This filter restricts which events are returned by the event store.
+ *
+ * It is an immutable value object, which is used as filter
+ * inside {@see EventStoreInterface::load()}.
+ *
+ * @api for the public methods; NOT for the inner state.
  */
 final class EventStreamFilter
 {
@@ -15,8 +20,33 @@ final class EventStreamFilter
     ) {
     }
 
-    public static function forEventTypes(EventTypes $eventTypes): self
-    {
+    /**
+     * Creates an instance with the specified filter options
+     *
+     * Note: The signature of this method might be extended in the future, so it should always be used with named arguments
+     * @see https://www.php.net/manual/en/functions.arguments.php#functions.named-arguments
+     *
+     * @param EventTypes|null $eventTypes
+     */
+    public static function create(
+        EventTypes $eventTypes = null,
+    ): self {
         return new self($eventTypes);
+    }
+
+    /**
+     * Returns a new instance with the specified additional filter options
+     *
+     * Note: The signature of this method might be extended in the future, so it should always be used with named arguments
+     * @see https://www.php.net/manual/en/functions.arguments.php#functions.named-arguments
+     *
+     * @param EventTypes|null $eventTypes
+     */
+    public function with(
+        EventTypes $eventTypes = null,
+    ): self {
+        return self::create(
+            $eventTypes ?? $this->eventTypes,
+        );
     }
 }

--- a/src/Model/EventStream/EventStreamFilter.php
+++ b/src/Model/EventStream/EventStreamFilter.php
@@ -1,0 +1,22 @@
+<?php
+declare(strict_types=1);
+namespace Neos\EventStore\Model\EventStream;
+
+use Neos\EventStore\Model\Event\EventTypes;
+use Webmozart\Assert\Assert;
+
+/**
+ * TODO
+ */
+final class EventStreamFilter
+{
+    private function __construct(
+        public readonly ?EventTypes $eventTypes,
+    ) {
+    }
+
+    public static function forEventTypes(EventTypes $eventTypes): self
+    {
+        return new self($eventTypes);
+    }
+}

--- a/tests/AbstractCheckpointStorageTestBase.php
+++ b/tests/AbstractCheckpointStorageTestBase.php
@@ -7,7 +7,7 @@ use Neos\EventStore\Exception\CheckpointException;
 use Neos\EventStore\Model\Event\SequenceNumber;
 use PHPUnit\Framework\TestCase;
 
-abstract class AbstractCheckpointStorageTest extends TestCase
+abstract class AbstractCheckpointStorageTestBase extends TestCase
 {
     abstract protected function createCheckpointStorage(string $subscriptionId): CheckpointStorageInterface;
 

--- a/tests/AbstractEventStoreTestBase.php
+++ b/tests/AbstractEventStoreTestBase.php
@@ -145,14 +145,14 @@ abstract class AbstractEventStoreTestBase extends TestCase
     {
         $this->commitDummyEvents();
 
-        self::assertEventStream($this->getEventStore()->load(VirtualStreamName::all(), EventStreamFilter::forEventTypes(EventTypes::create(EventType::fromString('NonExistingEventType')))), []);
+        self::assertEventStream($this->getEventStore()->load(VirtualStreamName::all(), EventStreamFilter::create(eventTypes: EventTypes::create(EventType::fromString('NonExistingEventType')))), []);
     }
 
     public function test_load_returns_filtered_events_matching_specified_evenTypes(): void
     {
         $this->commitDummyEvents();
 
-        self::assertEventStream($this->getEventStore()->load(VirtualStreamName::all(), EventStreamFilter::forEventTypes(EventTypes::create(EventType::fromString('SomeOtherEventType')))), [
+        self::assertEventStream($this->getEventStore()->load(VirtualStreamName::all(), EventStreamFilter::create(eventTypes: EventTypes::create(EventType::fromString('SomeOtherEventType')))), [
             ['sequenceNumber' => 2, 'type' => 'SomeOtherEventType', 'data' => 'b', 'metadata' => [], 'streamName' => 'first-stream', 'version' => 1],
             ['sequenceNumber' => 4, 'type' => 'SomeOtherEventType', 'data' => 'd', 'metadata' => [], 'streamName' => 'second-stream', 'version' => 0],
             ['sequenceNumber' => 6, 'type' => 'SomeOtherEventType', 'data' => 'f', 'metadata' => [], 'streamName' => 'second-stream', 'version' => 2],

--- a/tests/Helper/InMemoryCheckpointStorageTestBase.php
+++ b/tests/Helper/InMemoryCheckpointStorageTestBase.php
@@ -4,9 +4,9 @@ namespace Neos\EventStore\Tests\Helper;
 
 use Neos\EventStore\CatchUp\CheckpointStorageInterface;
 use Neos\EventStore\Helper\InMemoryCheckpointStorage;
-use Neos\EventStore\Tests\AbstractCheckpointStorageTest;
+use Neos\EventStore\Tests\AbstractCheckpointStorageTestBase;
 
-final class InMemoryCheckpointStorageTest extends AbstractCheckpointStorageTest
+final class InMemoryCheckpointStorageTestBase extends AbstractCheckpointStorageTestBase
 {
 
     public function tearDown(): void

--- a/tests/Helper/InMemoryEventStoreTestBase.php
+++ b/tests/Helper/InMemoryEventStoreTestBase.php
@@ -4,9 +4,9 @@ namespace Neos\EventStore\Tests\Helper;
 
 use Neos\EventStore\EventStoreInterface;
 use Neos\EventStore\Helper\InMemoryEventStore;
-use Neos\EventStore\Tests\AbstractEventStoreTest;
+use Neos\EventStore\Tests\AbstractEventStoreTestBase;
 
-final class InMemoryEventStoreTest extends AbstractEventStoreTest
+final class InMemoryEventStoreTestBase extends AbstractEventStoreTestBase
 {
 
     protected function createEventStore(): EventStoreInterface


### PR DESCRIPTION
Allows to filter events by their type:

```php
$filter = EventStreamFilter::forEventTypes(EventTypes::create(EventType::fromString('NonExistingEventType'))
$eventStore->load($stream, $filter);
```

Resolves: #5