### PR TITLE
FEATURE: Prune / Reset event store via `WithResetInterface`

### DIFF
--- a/src/EventStoreInterface.php
+++ b/src/EventStoreInterface.php
@@ -51,12 +51,4 @@ interface EventStoreInterface
      * @throws ConcurrencyException in case that the $expectedVersion check fails
      */
     public function commit(StreamName $streamName, Event|Events $events, ExpectedVersion $expectedVersion): CommitResult;
-
-    /**
-     * Permanently remove all events from the specified stream
-     * Note: Not all implementations might support this!
-     *
-     * @param StreamName $streamName Name of the stream to prune
-     */
-    public function deleteStream(StreamName $streamName): void;
 }

--- a/src/Helper/InMemoryEventStore.php
+++ b/src/Helper/InMemoryEventStore.php
@@ -17,13 +17,14 @@ use Neos\EventStore\Model\Event\Version;
 use Neos\EventStore\Model\EventStream\VirtualStreamName;
 use Neos\EventStore\Model\EventStream\VirtualStreamType;
 use Neos\EventStore\Model\Events;
+use Neos\EventStore\PrunableEventStoreInterface;
 
 /**
  * In-memorry implementation of an event store
  *
  * @internal This helper is mostly useful for testing purposes and should not be used in production
  */
-final class InMemoryEventStore implements EventStoreInterface
+final class InMemoryEventStore implements EventStoreInterface, PrunableEventStoreInterface
 {
     /**
      * @var EventEnvelope[]
@@ -106,6 +107,12 @@ final class InMemoryEventStore implements EventStoreInterface
             }
         }
         unset($this->streamVersions[$streamName->value]);
+    }
+
+    public function prune(): void
+    {
+        $this->events = [];
+        $this->sequenceNumber = null;
     }
 
     private function getStreamVersion(StreamName $streamName): MaybeVersion

--- a/src/Helper/InMemoryEventStore.php
+++ b/src/Helper/InMemoryEventStore.php
@@ -17,14 +17,14 @@ use Neos\EventStore\Model\Event\Version;
 use Neos\EventStore\Model\EventStream\VirtualStreamName;
 use Neos\EventStore\Model\EventStream\VirtualStreamType;
 use Neos\EventStore\Model\Events;
-use Neos\EventStore\PrunableEventStoreInterface;
+use Neos\EventStore\WithResetInterface;
 
 /**
  * In-memorry implementation of an event store
  *
  * @internal This helper is mostly useful for testing purposes and should not be used in production
  */
-final class InMemoryEventStore implements EventStoreInterface, PrunableEventStoreInterface
+final class InMemoryEventStore implements EventStoreInterface, WithResetInterface
 {
     /**
      * @var EventEnvelope[]
@@ -109,7 +109,7 @@ final class InMemoryEventStore implements EventStoreInterface, PrunableEventStor
         unset($this->streamVersions[$streamName->value]);
     }
 
-    public function prune(): void
+    public function reset(): void
     {
         $this->events = [];
         $this->sequenceNumber = null;

--- a/src/PrunableEventStoreInterface.php
+++ b/src/PrunableEventStoreInterface.php
@@ -1,0 +1,17 @@
+<?php
+declare(strict_types=1);
+namespace Neos\EventStore;
+
+/**
+ * Permanently remove events
+ * Note: Not all implementations might support this!
+ * @api
+ */
+interface PrunableEventStoreInterface
+{
+    /**
+     * Permanently remove all events from all streams.
+     * The sequence number is reset.
+     */
+    public function prune(): void;
+}

--- a/src/PrunableEventStoreInterface.php
+++ b/src/PrunableEventStoreInterface.php
@@ -2,6 +2,8 @@
 declare(strict_types=1);
 namespace Neos\EventStore;
 
+use Neos\EventStore\Model\Event\StreamName;
+
 /**
  * Permanently remove events
  * Note: Not all implementations might support this!
@@ -9,6 +11,13 @@ namespace Neos\EventStore;
  */
 interface PrunableEventStoreInterface
 {
+    /**
+     * Permanently remove all events from the specified stream
+     *
+     * @param StreamName $streamName Name of the stream to prune
+     */
+    public function deleteStream(StreamName $streamName): void;
+
     /**
      * Permanently remove all events from all streams.
      * The sequence number is reset.

--- a/src/WithResetInterface.php
+++ b/src/WithResetInterface.php
@@ -9,7 +9,7 @@ use Neos\EventStore\Model\Event\StreamName;
  * Note: Not all implementations might support this!
  * @api
  */
-interface PrunableEventStoreInterface
+interface WithResetInterface
 {
     /**
      * Permanently remove all events from the specified stream
@@ -22,5 +22,5 @@ interface PrunableEventStoreInterface
      * Permanently remove all events from all streams.
      * The sequence number is reset.
      */
-    public function prune(): void;
+    public function reset(): void;
 }

--- a/tests/Integration/AbstractEventStoreTestBase.php
+++ b/tests/Integration/AbstractEventStoreTestBase.php
@@ -21,7 +21,7 @@ use Neos\EventStore\Model\EventStream\MaybeVersion;
 use Neos\EventStore\Model\EventStream\VirtualStreamName;
 use Neos\EventStore\Model\Event;
 use Neos\EventStore\Model\Events;
-use Neos\EventStore\PrunableEventStoreInterface;
+use Neos\EventStore\WithResetInterface;
 use PHPUnit\Framework\Attributes\CoversNothing;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Group;
@@ -168,8 +168,8 @@ abstract class AbstractEventStoreTestBase extends TestCase
     public function test_deleteStream_does_not_reset_sequenceNumber(): void
     {
         $eventStore = $this->getEventStore();
-        if (!$eventStore instanceof PrunableEventStoreInterface) {
-            self::markTestSkipped(sprintf('EventStore %s does not allow pruning.', $eventStore::class));
+        if (!$eventStore instanceof WithResetInterface) {
+            self::markTestSkipped(sprintf('EventStore %s does not allow reset.', $eventStore::class));
         }
 
         $this->commitEvents(array_map(static fn ($char) => ['data' => $char], range('a', 'c')), 'first-stream');
@@ -185,8 +185,13 @@ abstract class AbstractEventStoreTestBase extends TestCase
 
     public function test_deleteStream_does_reset_version(): void
     {
+        $eventStore = $this->getEventStore();
+        if (!$eventStore instanceof WithResetInterface) {
+            self::markTestSkipped(sprintf('EventStore %s does not allow reset.', $eventStore::class));
+        }
+
         $this->commitEvents(array_map(static fn ($char) => ['data' => $char], range('a', 'c')), 'first-stream', ExpectedVersion::NO_STREAM());
-        $this->deleteStream('first-stream');
+        $eventStore->deleteStream(StreamName::fromString('first-stream'));
         $this->commitEvents(array_map(static fn ($char) => ['data' => $char], range('d', 'f')), 'first-stream', ExpectedVersion::NO_STREAM());
 
         self::assertEventStream($this->getEventStore()->load(VirtualStreamName::all()), [
@@ -196,16 +201,16 @@ abstract class AbstractEventStoreTestBase extends TestCase
         ]);
     }
 
-    public function test_prune_does_reset_sequenceNumber(): void
+    public function test_reset_does_reset_sequenceNumber(): void
     {
         $eventStore = $this->getEventStore();
-        if (!$eventStore instanceof PrunableEventStoreInterface) {
-            self::markTestSkipped(sprintf('EventStore %s does not allow pruning.', $eventStore::class));
+        if (!$eventStore instanceof WithResetInterface) {
+            self::markTestSkipped(sprintf('EventStore %s does not allow reset.', $eventStore::class));
         }
 
         $this->commitEvents(array_map(static fn ($char) => ['data' => $char], range('a', 'c')), 'first-stream');
         $this->commitEvents(array_map(static fn ($char) => ['data' => $char], range('d', 'f')), 'second-stream');
-        $eventStore->prune();
+        $eventStore->reset();
         $this->commitEvents(array_map(static fn ($char) => ['data' => $char], range('g', 'i')), 'third-stream');
 
         self::assertEventStream($this->getEventStore()->load(VirtualStreamName::all()), [
@@ -318,8 +323,8 @@ abstract class AbstractEventStoreTestBase extends TestCase
         $eventStore = $this->getEventStore();
 
         /** If the EventStore does not allow pruning {@see createEventStore} must return a new instance */
-        if ($eventStore instanceof PrunableEventStoreInterface) {
-            $eventStore->prune();
+        if ($eventStore instanceof WithResetInterface) {
+            $eventStore->reset();
         }
     }
 

--- a/tests/Integration/AbstractEventStoreTestBase.php
+++ b/tests/Integration/AbstractEventStoreTestBase.php
@@ -192,6 +192,20 @@ abstract class AbstractEventStoreTestBase extends TestCase
         ]);
     }
 
+    public function test_prune_does_reset_sequenceNumber(): void
+    {
+        $this->commitEvents(array_map(static fn ($char) => ['data' => $char], range('a', 'c')), 'first-stream');
+        $this->commitEvents(array_map(static fn ($char) => ['data' => $char], range('d', 'f')), 'second-stream');
+        $this->prune();
+        $this->commitEvents(array_map(static fn ($char) => ['data' => $char], range('g', 'i')), 'third-stream');
+
+        self::assertEventStream($this->getEventStore()->load(VirtualStreamName::all()), [
+            ['sequenceNumber' => 1],
+            ['sequenceNumber' => 2],
+            ['sequenceNumber' => 3],
+        ]);
+    }
+
     public function test_loaded_events_contain_metadata(): void
     {
         $this->commitEvent(['metadata' => ['foo' => 'bar']]);
@@ -323,6 +337,11 @@ abstract class AbstractEventStoreTestBase extends TestCase
     final protected function deleteStream(string $streamName): void
     {
         $this->getEventStore()->deleteStream(StreamName::fromString($streamName));
+    }
+
+    final protected function prune(): void
+    {
+        $this->getEventStore()->prune();
     }
 
     /**

--- a/tests/Integration/AbstractEventStoreTestBase.php
+++ b/tests/Integration/AbstractEventStoreTestBase.php
@@ -21,6 +21,7 @@ use Neos\EventStore\Model\EventStream\MaybeVersion;
 use Neos\EventStore\Model\EventStream\VirtualStreamName;
 use Neos\EventStore\Model\Event;
 use Neos\EventStore\Model\Events;
+use Neos\EventStore\PrunableEventStoreInterface;
 use PHPUnit\Framework\Attributes\CoversNothing;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Group;
@@ -32,8 +33,6 @@ abstract class AbstractEventStoreTestBase extends TestCase
     private ?EventStoreInterface $eventStore = null;
 
     abstract protected static function createEventStore(): EventStoreInterface;
-
-    abstract protected static function resetEventStore(): void;
 
     // --- Tests ----
 
@@ -168,8 +167,13 @@ abstract class AbstractEventStoreTestBase extends TestCase
 
     public function test_deleteStream_does_not_reset_sequenceNumber(): void
     {
+        $eventStore = $this->getEventStore();
+        if (!$eventStore instanceof PrunableEventStoreInterface) {
+            self::markTestSkipped(sprintf('EventStore %s does not allow pruning.', $eventStore::class));
+        }
+
         $this->commitEvents(array_map(static fn ($char) => ['data' => $char], range('a', 'c')), 'first-stream');
-        $this->deleteStream('first-stream');
+        $eventStore->deleteStream(StreamName::fromString('first-stream'));
         $this->commitEvents(array_map(static fn ($char) => ['data' => $char], range('d', 'f')), 'second-stream');
 
         self::assertEventStream($this->getEventStore()->load(VirtualStreamName::all()), [
@@ -194,9 +198,14 @@ abstract class AbstractEventStoreTestBase extends TestCase
 
     public function test_prune_does_reset_sequenceNumber(): void
     {
+        $eventStore = $this->getEventStore();
+        if (!$eventStore instanceof PrunableEventStoreInterface) {
+            self::markTestSkipped(sprintf('EventStore %s does not allow pruning.', $eventStore::class));
+        }
+
         $this->commitEvents(array_map(static fn ($char) => ['data' => $char], range('a', 'c')), 'first-stream');
         $this->commitEvents(array_map(static fn ($char) => ['data' => $char], range('d', 'f')), 'second-stream');
-        $this->prune();
+        $eventStore->prune();
         $this->commitEvents(array_map(static fn ($char) => ['data' => $char], range('g', 'i')), 'third-stream');
 
         self::assertEventStream($this->getEventStore()->load(VirtualStreamName::all()), [
@@ -306,7 +315,12 @@ abstract class AbstractEventStoreTestBase extends TestCase
 
     public function tearDown(): void
     {
-        static::resetEventStore();
+        $eventStore = $this->getEventStore();
+
+        /** If the EventStore does not allow pruning {@see createEventStore} must return a new instance */
+        if ($eventStore instanceof PrunableEventStoreInterface) {
+            $eventStore->prune();
+        }
     }
 
 
@@ -332,16 +346,6 @@ abstract class AbstractEventStoreTestBase extends TestCase
     final protected function commitEvent(array $event, string $streamName = 'some-stream', ?ExpectedVersion $expectedVersion = null): CommitResult
     {
         return $this->commitEvents([$event], $streamName, $expectedVersion);
-    }
-
-    final protected function deleteStream(string $streamName): void
-    {
-        $this->getEventStore()->deleteStream(StreamName::fromString($streamName));
-    }
-
-    final protected function prune(): void
-    {
-        $this->getEventStore()->prune();
     }
 
     /**

--- a/tests/Unit/Helper/InMemoryEventStoreTest.php
+++ b/tests/Unit/Helper/InMemoryEventStoreTest.php
@@ -15,8 +15,4 @@ final class InMemoryEventStoreTest extends AbstractEventStoreTestBase
     {
         return new InMemoryEventStore();
     }
-
-    protected static function resetEventStore(): void
-    {
-    }
 }


### PR DESCRIPTION
Resolves: https://github.com/neos/eventstore/issues/23

During testing or development we reset the event store. And during testing its crucial that the sequence numbers are reset to ensure assertions based on the count work and we start fresh.

That is handled in `resetEventStore` in the tests of this package but unfortunately not exposed. Instead to avoid the same hack and adapter specific handling like for postgreSQL "RESTART IDENTITY" i like to propose to have that responsibility on the event store itself.

This is done with a new interface wich incapsulates all destructive operations. Also the `removeStream` method was moved there. This is not breaking as only PHPStan would complain but the method is still callable.

All adapter implementations though should need to implement the new prune method to ensure the test runs but again not breaking.

In Neos we then can get rid of hacks like https://github.com/neos/neos-development-collection/pull/5792

```php
// We TRUNCATE here and do not want to use $contentRepositoryMaintainer->prune(); here as it would not reset the autoincrement sequence number making some assertions impossible

/** @var Connection $databaseConnection */
$databaseConnection = (new \ReflectionClass($eventStore))->getProperty('connection')->getValue($eventStore);
$eventTableName = sprintf('cr_%s_events', $contentRepositoryId->value);
if ($databaseConnection->getDatabasePlatform() instanceof PostgreSQLPlatform) {
    $databaseConnection->executeStatement('TRUNCATE ' . $eventTableName . ' RESTART IDENTITY');
} else {
    $databaseConnection->executeStatement('TRUNCATE ' . $eventTableName);
}
```

And write the following:

```php
$contentRepositoryMaintainer->prune();
```

Which would leverage internally the new 'prune' method instead of

```php
// prune all streams:
foreach ($this->findAllContentStreamStreamNames() as $contentStreamStreamName) {
    $this->eventStore->deleteStream($contentStreamStreamName);
}
foreach ($this->findAllWorkspaceStreamNames() as $workspaceStreamName) {
    $this->eventStore->deleteStream($workspaceStreamName);
}
```
