### PR TITLE
BUGFIX: Reduce memory footprint in `InMemoryEventStore::getStreamVersion`

### DIFF
--- a/src/Helper/InMemoryEventStore.php
+++ b/src/Helper/InMemoryEventStore.php
@@ -105,6 +105,7 @@ final class InMemoryEventStore implements EventStoreInterface
                 unset($this->events[$index]);
             }
         }
+        unset($this->streamVersions[$streamName->value]);
     }
 
     private function getStreamVersion(StreamName $streamName): MaybeVersion

--- a/src/Helper/InMemoryEventStore.php
+++ b/src/Helper/InMemoryEventStore.php
@@ -30,6 +30,11 @@ final class InMemoryEventStore implements EventStoreInterface
      */
     private array $events = [];
 
+    /**
+     * @var array<string,Version>
+     */
+    private array $streamVersions = [];
+
     private ?SequenceNumber $sequenceNumber = null;
 
     public function setup(): void
@@ -71,6 +76,7 @@ final class InMemoryEventStore implements EventStoreInterface
         $lastCommittedVersion = $version;
         foreach ($events as $event) {
             $this->sequenceNumber = $this->sequenceNumber->next();
+            $this->streamVersions[$streamName->value] = $version;
             $this->events[] = new EventEnvelope(
                 new Event(
                     $event->id,
@@ -103,13 +109,6 @@ final class InMemoryEventStore implements EventStoreInterface
 
     private function getStreamVersion(StreamName $streamName): MaybeVersion
     {
-        /** @var Version|null $version */
-        $version = null;
-        foreach ($this->events as $event) {
-            if ($event->streamName->equals($streamName)) {
-                $version = $event->version;
-            }
-        }
-        return MaybeVersion::fromVersionOrNull($version);
+        return MaybeVersion::fromVersionOrNull($this->streamVersions[$streamName->value] ?? null);
     }
 }

--- a/tests/Integration/AbstractEventStoreTestBase.php
+++ b/tests/Integration/AbstractEventStoreTestBase.php
@@ -179,6 +179,19 @@ abstract class AbstractEventStoreTestBase extends TestCase
         ]);
     }
 
+    public function test_deleteStream_does_reset_version(): void
+    {
+        $this->commitEvents(array_map(static fn ($char) => ['data' => $char], range('a', 'c')), 'first-stream', ExpectedVersion::NO_STREAM());
+        $this->deleteStream('first-stream');
+        $this->commitEvents(array_map(static fn ($char) => ['data' => $char], range('d', 'f')), 'first-stream', ExpectedVersion::NO_STREAM());
+
+        self::assertEventStream($this->getEventStore()->load(VirtualStreamName::all()), [
+            ['streamName' => 'first-stream', 'version' => 0],
+            ['streamName' => 'first-stream', 'version' => 1],
+            ['streamName' => 'first-stream', 'version' => 2],
+        ]);
+    }
+
     public function test_loaded_events_contain_metadata(): void
     {
         $this->commitEvent(['metadata' => ['foo' => 'bar']]);


### PR DESCRIPTION

The InMemoryEventStore is used by the NEOS ESCR during publishing. See CommandSimulation from https://github.com/neos/neos-development-collection/pull/5301

And publishing a large amount of changes e.g. 5000 nodes results in

```
InMemoryEventStore::getStreamVersion
Time & OwnTime: 9.5 | 4.8%
Memory & OwnMemory: 1.000.200.000
```