### PR TITLE
BUGFIX: Provide test to ensure event-store implementation always uses UTC dates

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,8 @@
     "require": {
         "php": "^8.2",
         "webmozart/assert": "^1.10",
-        "ramsey/uuid": "^4.3"
+        "ramsey/uuid": "^4.3",
+        "psr/clock": "^1"
     },
     "require-dev": {
         "roave/security-advisories": "dev-latest",

--- a/src/Helper/InMemoryEventStore.php
+++ b/src/Helper/InMemoryEventStore.php
@@ -17,6 +17,7 @@ use Neos\EventStore\Model\Event\Version;
 use Neos\EventStore\Model\EventStream\VirtualStreamName;
 use Neos\EventStore\Model\EventStream\VirtualStreamType;
 use Neos\EventStore\Model\Events;
+use Psr\Clock\ClockInterface;
 use Neos\EventStore\WithResetInterface;
 
 /**
@@ -37,6 +38,19 @@ final class InMemoryEventStore implements EventStoreInterface, WithResetInterfac
     private array $streamVersions = [];
 
     private ?SequenceNumber $sequenceNumber = null;
+
+    private readonly ClockInterface $clock;
+
+    public function __construct(
+        ?ClockInterface $clock = null
+    ) {
+        $this->clock = $clock ?? new class implements ClockInterface {
+            public function now(): \DateTimeImmutable
+            {
+                return new \DateTimeImmutable();
+            }
+        };
+    }
 
     public function setup(): void
     {
@@ -72,7 +86,6 @@ final class InMemoryEventStore implements EventStoreInterface, WithResetInterfac
         $maybeVersion = $this->getStreamVersion($streamName);
         $expectedVersion->verifyVersion($maybeVersion);
         $version = $maybeVersion->isNothing() ? Version::first() : $maybeVersion->unwrap()->next();
-        $now = new \DateTimeImmutable();
         $this->sequenceNumber = $this->sequenceNumber ?? SequenceNumber::none();
         $lastCommittedVersion = $version;
         foreach ($events as $event) {
@@ -90,7 +103,7 @@ final class InMemoryEventStore implements EventStoreInterface, WithResetInterfac
                 $streamName,
                 $version,
                 $this->sequenceNumber,
-                $now
+                $this->clock->now()
             );
             $lastCommittedVersion = $version;
             $version = $version->next();

--- a/src/Helper/InMemoryEventStore.php
+++ b/src/Helper/InMemoryEventStore.php
@@ -103,7 +103,7 @@ final class InMemoryEventStore implements EventStoreInterface, WithResetInterfac
                 $streamName,
                 $version,
                 $this->sequenceNumber,
-                $this->clock->now()
+                $this->clock->now()->setTimezone(new \DateTimeZone('UTC'))
             );
             $lastCommittedVersion = $version;
             $version = $version->next();

--- a/tests/Integration/AbstractEventStoreTestBase.php
+++ b/tests/Integration/AbstractEventStoreTestBase.php
@@ -32,6 +32,9 @@ abstract class AbstractEventStoreTestBase extends TestCase
 {
     private ?EventStoreInterface $eventStore = null;
 
+    /**
+     * Must use {@see EventStoreFakeClock} for testing.
+     */
     abstract protected static function createEventStore(): EventStoreInterface;
 
     // --- Tests ----
@@ -228,6 +231,65 @@ abstract class AbstractEventStoreTestBase extends TestCase
         self::assertEventStream($this->getEventStore()->load(VirtualStreamName::all()), [
             ['sequenceNumber' => 1, 'metadata' => ['foo' => 'bar']],
             ['sequenceNumber' => 2, 'metadata' => ['bar' => 'baz']],
+        ]);
+    }
+
+    public function test_loaded_events_contain_recorded_at(): void
+    {
+        $defaultSystemTimezone = date_default_timezone_get();
+
+        // Ensure test also passes on non UTC systems
+        date_default_timezone_set('America/El_Salvador');
+
+        $firstDate = \DateTimeImmutable::createFromFormat(
+            \DateTimeImmutable::ATOM,
+            '2024-09-22T12:00:00+00:00'
+        );
+        EventStoreFakeClock::setNow($firstDate);
+        $this->commitEvent(['data' => 'a']);
+
+        $secondDate = \DateTimeImmutable::createFromFormat(
+            \DateTimeImmutable::ATOM,
+            '2024-09-23T13:00:00+00:00'
+        );
+        EventStoreFakeClock::setNow($secondDate);
+        $this->commitEvent(['data' => 'b']);
+
+        self::assertEventStream($this->getEventStore()->load(VirtualStreamName::all()), [
+            ['sequenceNumber' => 1, 'recordedAt' => $firstDate],
+            ['sequenceNumber' => 2, 'recordedAt' => $secondDate],
+        ]);
+
+        date_default_timezone_set($defaultSystemTimezone);
+    }
+
+    public function test_loaded_events_contain_recorded_at_in_utc(): void
+    {
+        $firstDateCet = \DateTimeImmutable::createFromFormat(
+            \DateTimeImmutable::ATOM,
+            '2024-09-22T13:00:00+01:00'
+        );
+        EventStoreFakeClock::setNow($firstDateCet);
+        $this->commitEvent(['data' => 'a']);
+
+        $secondDateJst = \DateTimeImmutable::createFromFormat(
+            \DateTimeImmutable::ATOM,
+            '2024-09-23T22:00:00+09:00'
+        );
+        EventStoreFakeClock::setNow($secondDateJst);
+        $this->commitEvent(['data' => 'b']);
+
+        $firstDateUtc = \DateTimeImmutable::createFromFormat(
+            \DateTimeImmutable::ATOM,
+            '2024-09-22T12:00:00+00:00'
+        );
+        $secondDateUtc = \DateTimeImmutable::createFromFormat(
+            \DateTimeImmutable::ATOM,
+            '2024-09-23T13:00:00+00:00'
+        );
+        self::assertEventStream($this->getEventStore()->load(VirtualStreamName::all()), [
+            ['sequenceNumber' => 1, 'recordedAt' => $firstDateUtc],
+            ['sequenceNumber' => 2, 'recordedAt' => $secondDateUtc],
         ]);
     }
 

--- a/tests/Integration/AbstractEventStoreTestBase.php
+++ b/tests/Integration/AbstractEventStoreTestBase.php
@@ -241,15 +241,14 @@ abstract class AbstractEventStoreTestBase extends TestCase
         // Ensure test also passes on non UTC systems
         date_default_timezone_set('America/El_Salvador');
 
-        $firstDate = \DateTimeImmutable::createFromFormat(
-            \DateTimeImmutable::ATOM,
+        $firstDate = new \DateTimeImmutable(
             '2024-09-22T12:00:00+00:00'
         );
+        self::assertSame($firstDate->getOffset(), 0);
         EventStoreFakeClock::setNow($firstDate);
         $this->commitEvent(['data' => 'a']);
 
-        $secondDate = \DateTimeImmutable::createFromFormat(
-            \DateTimeImmutable::ATOM,
+        $secondDate = new \DateTimeImmutable(
             '2024-09-23T13:00:00+00:00'
         );
         EventStoreFakeClock::setNow($secondDate);
@@ -265,17 +264,17 @@ abstract class AbstractEventStoreTestBase extends TestCase
 
     public function test_loaded_events_contain_recorded_at_in_utc(): void
     {
-        $firstDateCet = \DateTimeImmutable::createFromFormat(
-            \DateTimeImmutable::ATOM,
+        $firstDateCet = new \DateTimeImmutable(
             '2024-09-22T13:00:00+01:00'
         );
+        self::assertSame($firstDateCet->getOffset(), 60 * 60);
         EventStoreFakeClock::setNow($firstDateCet);
         $this->commitEvent(['data' => 'a']);
 
-        $secondDateJst = \DateTimeImmutable::createFromFormat(
-            \DateTimeImmutable::ATOM,
+        $secondDateJst = new \DateTimeImmutable(
             '2024-09-23T22:00:00+09:00'
         );
+        self::assertSame($secondDateJst->getOffset(), 9 * 60 * 60);
         EventStoreFakeClock::setNow($secondDateJst);
         $this->commitEvent(['data' => 'b']);
 
@@ -417,7 +416,7 @@ abstract class AbstractEventStoreTestBase extends TestCase
 
     /**
      * @param EventStreamInterface $eventStream
-     * @param array<array{id?: string, type?: string, data?: string, metadata?: array<mixed>|null, causationId?: string|null, correlationId?: string|null, streamName?: string, version?: int, sequenceNumber?: int, recordedAt?: \DateTimeInterface}> $expectedEvents
+     * @param array<array{id?: string, type?: string, data?: string, metadata?: array<mixed>|null, causationId?: string|null, correlationId?: string|null, streamName?: string, version?: int, sequenceNumber?: int, recordedAt?: string}> $expectedEvents
      */
     final protected static function assertEventStream(EventStreamInterface $eventStream, array $expectedEvents): void
     {
@@ -449,7 +448,7 @@ abstract class AbstractEventStoreTestBase extends TestCase
     /**
      * @param string[] $keys
      * @param EventEnvelope $eventEnvelope
-     * @return array{id?: string, type?: string, data?: string, metadata?: array<mixed>|null, causationId?: string|null, correlationId?: string|null, streamName?: string, version?: int, sequenceNumber?: int, recordedAt?: \DateTimeInterface}
+     * @return array{id?: string, type?: string, data?: string, metadata?: array<mixed>|null, causationId?: string|null, correlationId?: string|null, streamName?: string, version?: int, sequenceNumber?: int, recordedAt?: string}
      */
     private static function eventEnvelopeToArray(array $keys, EventEnvelope $eventEnvelope): array
     {

--- a/tests/Integration/AbstractEventStoreTestBase.php
+++ b/tests/Integration/AbstractEventStoreTestBase.php
@@ -256,8 +256,8 @@ abstract class AbstractEventStoreTestBase extends TestCase
         $this->commitEvent(['data' => 'b']);
 
         self::assertEventStream($this->getEventStore()->load(VirtualStreamName::all()), [
-            ['sequenceNumber' => 1, 'recordedAt' => $firstDate],
-            ['sequenceNumber' => 2, 'recordedAt' => $secondDate],
+            ['sequenceNumber' => 1, 'recordedAt' => '2024-09-22T12:00:00+00:00'],
+            ['sequenceNumber' => 2, 'recordedAt' => '2024-09-23T13:00:00+00:00'],
         ]);
 
         date_default_timezone_set($defaultSystemTimezone);
@@ -279,17 +279,9 @@ abstract class AbstractEventStoreTestBase extends TestCase
         EventStoreFakeClock::setNow($secondDateJst);
         $this->commitEvent(['data' => 'b']);
 
-        $firstDateUtc = \DateTimeImmutable::createFromFormat(
-            \DateTimeImmutable::ATOM,
-            '2024-09-22T12:00:00+00:00'
-        );
-        $secondDateUtc = \DateTimeImmutable::createFromFormat(
-            \DateTimeImmutable::ATOM,
-            '2024-09-23T13:00:00+00:00'
-        );
         self::assertEventStream($this->getEventStore()->load(VirtualStreamName::all()), [
-            ['sequenceNumber' => 1, 'recordedAt' => $firstDateUtc],
-            ['sequenceNumber' => 2, 'recordedAt' => $secondDateUtc],
+            ['sequenceNumber' => 1, 'recordedAt' => '2024-09-22T12:00:00+00:00'],
+            ['sequenceNumber' => 2, 'recordedAt' => '2024-09-23T13:00:00+00:00'],
         ]);
     }
 
@@ -476,7 +468,7 @@ abstract class AbstractEventStoreTestBase extends TestCase
             'streamName' => $eventEnvelope->streamName->value,
             'version' => $eventEnvelope->version->value,
             'sequenceNumber' => $eventEnvelope->sequenceNumber->value,
-            'recordedAt' => $eventEnvelope->recordedAt,
+            'recordedAt' => $eventEnvelope->recordedAt->format(\DateTimeImmutable::ATOM),
         ];
         foreach (array_diff($supportedKeys, $keys) as $unusedKey) {
             unset($actualAsArray[$unusedKey]);

--- a/tests/Integration/EventStoreFakeClock.php
+++ b/tests/Integration/EventStoreFakeClock.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Neos\EventStore\Tests\Integration;
+
+use Psr\Clock\ClockInterface;
+
+/**
+ * Clock implementation for tests
+ * This is a mutable class in order to allow to adjust the behaviour during runtime for testing purposes
+ */
+final class EventStoreFakeClock implements ClockInterface
+{
+    private static ?self $instance = null;
+
+    private function __construct(
+        private ?\DateTimeImmutable $now = null
+    ) {
+    }
+
+    public static function get(): self
+    {
+        return self::$instance ??= new self();
+    }
+
+    public static function setNow(\DateTimeImmutable $now): void
+    {
+        self::get()->now = $now;
+    }
+
+    public function now(): \DateTimeImmutable
+    {
+        return $this->now ?? new \DateTimeImmutable();
+    }
+}

--- a/tests/Unit/Helper/InMemoryEventStoreTest.php
+++ b/tests/Unit/Helper/InMemoryEventStoreTest.php
@@ -5,6 +5,7 @@ namespace Neos\EventStore\Tests\Unit\Helper;
 use Neos\EventStore\EventStoreInterface;
 use Neos\EventStore\Helper\InMemoryEventStore;
 use Neos\EventStore\Tests\Integration\AbstractEventStoreTestBase;
+use Neos\EventStore\Tests\Integration\EventStoreFakeClock;
 use PHPUnit\Framework\Attributes\CoversClass;
 
 #[CoversClass(InMemoryEventStore::class)]
@@ -13,6 +14,8 @@ final class InMemoryEventStoreTest extends AbstractEventStoreTestBase
 
     protected static function createEventStore(): EventStoreInterface
     {
-        return new InMemoryEventStore();
+        return new InMemoryEventStore(
+            clock: EventStoreFakeClock::get()
+        );
     }
 }


### PR DESCRIPTION
and allow specifying clock for testing `InMemoryEventStore`
